### PR TITLE
SDK-80 Add suppport for springreload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<tomcat.version>7.0.67</tomcat.version>
 	</properties>
 
 	<dependencies>
@@ -142,6 +143,49 @@
 			<artifactId>mysql-connector-java</artifactId>
 			<version>5.1.36</version>
 		</dependency>
+
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<version>1.4.190</version>
+		</dependency>
+
+		<!-- tomcat -->
+		<dependency>
+			<groupId>org.apache.tomcat.embed</groupId>
+			<artifactId>tomcat-embed-core</artifactId>
+			<version>${tomcat.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat.embed</groupId>
+			<artifactId>tomcat-embed-logging-juli</artifactId>
+			<version>${tomcat.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat.embed</groupId>
+			<artifactId>tomcat-embed-jasper</artifactId>
+			<version>${tomcat.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>tomcat-jasper</artifactId>
+			<version>${tomcat.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>tomcat-jasper-el</artifactId>
+			<version>${tomcat.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>tomcat-jsp-api</artifactId>
+			<version>${tomcat.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>jstl</artifactId>
+			<version>1.2</version>
+	  	</dependency>
 	</dependencies>
 
 	<build>
@@ -151,6 +195,7 @@
 				<filtering>true</filtering>
 				<includes>
 					<include>**/*.yaml</include>
+					<include>sdk.properties</include>
 				</includes>
 			</resource>
 			<resource>
@@ -158,6 +203,7 @@
 				<filtering>false</filtering>
 				<excludes>
 					<exclude>**/*.yaml</exclude>
+					<exclude>sdk.properties</exclude>
 				</excludes>
 			</resource>
 		</resources>
@@ -186,8 +232,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.5.1</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/org/openmrs/maven/plugins/Delete.java
+++ b/src/main/java/org/openmrs/maven/plugins/Delete.java
@@ -32,10 +32,10 @@ public class Delete extends AbstractMojo{
     Wizard wizard;
 
     public void execute() throws MojoExecutionException, MojoFailureException {
-        File server = wizard.getServerPath(serverId);
+        serverId = wizard.promptForExistingServerIdIfMissing(serverId);
         try {
-            Server props = Server.loadServer(server);
-            FileUtils.deleteDirectory(server);
+            Server props = Server.loadServer(serverId);
+            FileUtils.deleteDirectory(props.getServerDirectory());
             String dbName = props.getParam(Server.PROPERTY_DB_NAME);
             String dbUser = props.getParam(Server.PROPERTY_DB_USER);
             String dbPass = props.getParam(Server.PROPERTY_DB_PASS);
@@ -43,7 +43,7 @@ public class Delete extends AbstractMojo{
             DBConnector connector = new DBConnector(dbUri, dbUser, dbPass, dbName);
             connector.dropDatabase();
             connector.close();
-            getLog().info(String.format(TEMPLATE_SUCCESS, server.getName()));
+            getLog().info(String.format(TEMPLATE_SUCCESS, props.getServerId()));
         } catch (IOException e) {
             throw new MojoExecutionException(e.getMessage());
         } catch (SQLException e) {

--- a/src/main/java/org/openmrs/maven/plugins/Help.java
+++ b/src/main/java/org/openmrs/maven/plugins/Help.java
@@ -60,7 +60,7 @@ public class Help extends AbstractMojo {
                 }
                 formatter.printHelp(m.get("name").toString(), header, options, "");
             }
-            writer.println(" -Djetty.port Port to execute OpenMRS server");
+            writer.println(" -Dport Port on which to run server");
             writer.flush();
         } catch (EOFException e) {
             throw new MojoExecutionException(e.getMessage());

--- a/src/main/java/org/openmrs/maven/plugins/Info.java
+++ b/src/main/java/org/openmrs/maven/plugins/Info.java
@@ -31,9 +31,9 @@ public class Info extends AbstractMojo {
 
 	@Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-	    File serverPath = wizard.getServerPath(serverId);
+	    serverId = wizard.promptForExistingServerIdIfMissing(serverId);
            
-        Server serverConfig = Server.loadServer(serverPath);
+        Server serverConfig = Server.loadServer(serverId);
         Set<Project> watchedProjects = serverConfig.getWatchedProjects();
         
         getLog().info(" ");

--- a/src/main/java/org/openmrs/maven/plugins/ModuleInstall.java
+++ b/src/main/java/org/openmrs/maven/plugins/ModuleInstall.java
@@ -107,7 +107,9 @@ public class ModuleInstall extends AbstractMojo {
             File currentProperties = wizard.getCurrentServerPath();
             if (currentProperties != null) serverId = currentProperties.getName();
         }
-        File serverPath = wizard.getServerPath(serverId);
+
+        serverId = wizard.promptForExistingServerIdIfMissing(serverId);
+        File serverPath = Server.loadServer(serverId).getServerDirectory();
         Artifact artifact = checkCurrentDirectoryForOpenmrsCoreVersion(serverPath);
 
         if(artifact != null){
@@ -150,8 +152,9 @@ public class ModuleInstall extends AbstractMojo {
         List<Element> artifactItems = new ArrayList<Element>();
         Server properties = Server.loadServer(serverPath);
         Artifact artifact = getArtifactForSelectedParameters(groupId, artifactId, version);
+
         artifact.setArtifactId(artifact.getArtifactId() + "-omod");
-        File modules = new File(serverPath, SDKConstants.OPENMRS_SERVER_MODULES);
+        File modules = new File(properties.getServerDirectory(), SDKConstants.OPENMRS_SERVER_MODULES);
         modules.mkdirs();
         artifactItems.add(artifact.toElement(modules.getPath()));
 

--- a/src/main/java/org/openmrs/maven/plugins/ModuleUninstall.java
+++ b/src/main/java/org/openmrs/maven/plugins/ModuleUninstall.java
@@ -43,15 +43,16 @@ public class ModuleUninstall extends AbstractMojo {
             File currentProperties = wizard.getCurrentServerPath();
             if (currentProperties != null) serverId = currentProperties.getName();
         }
-        File serverPath = wizard.getServerPath(serverId);
+        serverId = wizard.promptForExistingServerIdIfMissing(serverId);
+        Server server = Server.loadServer(serverId);
         Artifact artifact = installer.getArtifactForSelectedParameters(groupId, artifactId, "default");
-        File modules = new File(serverPath, SDKConstants.OPENMRS_SERVER_MODULES);
+        File modules = new File(server.getServerDirectory(), SDKConstants.OPENMRS_SERVER_MODULES);
         File[] listOfModules = modules.listFiles();
         for (File mod : listOfModules) {
             if (mod.getName().startsWith(artifact.getArtifactId())) {
                 boolean deleted = mod.delete();
                 if (deleted) {
-                    Server properties = Server.loadServer(serverPath);
+                    Server properties = Server.loadServer(serverId);
                     properties.removeFromValueList(Server.PROPERTY_USER_MODULES, artifact.getArtifactId());
                     properties.save();
                     getLog().info(String.format("Module with groupId: '%s', artifactId: '%s' was successfully removed from server.",

--- a/src/main/java/org/openmrs/maven/plugins/Reset.java
+++ b/src/main/java/org/openmrs/maven/plugins/Reset.java
@@ -70,11 +70,11 @@ public class Reset extends AbstractMojo{
             File currentProperties = wizard.getCurrentServerPath();
             if (currentProperties != null) serverId = currentProperties.getName();
         }
-        File serverPath = wizard.getServerPath(serverId);
-        Server properties = Server.loadServer(serverPath);
+        serverId = wizard.promptForExistingServerIdIfMissing(serverId);
+        Server properties = Server.loadServer(serverId);
         DBConnector connector = null;
         try {
-            String dbName = String.format(SDKConstants.DB_NAME_TEMPLATE, serverPath.getName());
+            String dbName = String.format(SDKConstants.DB_NAME_TEMPLATE, serverId);
             String uri = properties.getParam(Server.PROPERTY_DB_URI);
             uri = uri.substring(0, uri.lastIndexOf("/"));
             connector = new DBConnector(uri, properties.getParam(Server.PROPERTY_DB_USER),
@@ -104,7 +104,7 @@ public class Reset extends AbstractMojo{
         if (wizard.checkYes(full)) {
             try {
                 Setup platform = new Setup(mavenProject, mavenSession, pluginManager);
-                FileUtils.deleteDirectory(serverPath);
+                FileUtils.deleteDirectory(server.getServerDirectory());
                 platform.setup(server, isPlatform, true);
                 getLog().info(String.format(TEMPLATE_SUCCESS_FULL, server.getServerId()));
             } catch (IOException e) {

--- a/src/main/java/org/openmrs/maven/plugins/Run.java
+++ b/src/main/java/org/openmrs/maven/plugins/Run.java
@@ -1,21 +1,23 @@
 package org.openmrs.maven.plugins;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
+import org.openmrs.maven.plugins.model.Artifact;
 import org.openmrs.maven.plugins.model.Server;
 import org.openmrs.maven.plugins.utility.Project;
 import org.openmrs.maven.plugins.utility.SDKConstants;
 import org.openmrs.maven.plugins.utility.Wizard;
-import org.twdata.maven.mojoexecutor.MojoExecutor.*;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
+import java.util.Locale;
 
 import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
 
@@ -25,135 +27,173 @@ import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
  */
 public class Run extends AbstractMojo {
 
-    private static final String NO_SERVER_TEXT = "There no server with given serverId. Please create it using omrs:setup first";
+	/**
+	 * @parameter expression="${serverId}"
+	 */
+	private String serverId;
 
-    /**
-     * @parameter expression="${serverId}"
-     */
-    private String serverId;
+	/**
+	 * @parameter expression="${port}"
+	 */
+	private Integer port;
 
-    /**
-     * The project currently being build.
-     *
-     * @parameter expression="${project}"
-     * @required
-     */
-    private MavenProject mavenProject;
+	/**
+	 * @parameter expression="${debug}"
+	 */
+	private String debug;
 
-    /**
-     * The current Maven session.
-     *
-     * @parameter expression="${session}"
-     * @required
-     */
-    private MavenSession mavenSession;
+	/**
+	 * @parameter expression="${fork}"
+	 */
+	private Boolean fork;
 
-    /**
-     * The Maven BuildPluginManager component.
-     *
-     * @component
-     * @required
-     */
-    private BuildPluginManager pluginManager;
+	/**
+	 * The project currently being build.
+	 *
+	 * @parameter expression="${project}"
+	 * @required
+	 */
+	private MavenProject mavenProject;
 
-    /**
-     * @required
-     * @component
-     */
-    Wizard wizard;
+	/**
+	 * The current Maven session.
+	 *
+	 * @parameter expression="${session}"
+	 * @required
+	 */
+	private MavenSession mavenSession;
 
-    public void execute() throws MojoExecutionException, MojoFailureException {
-        if (serverId == null) {
-            File currentProperties = wizard.getCurrentServerPath();
-            if (currentProperties != null) serverId = currentProperties.getName();
-        }
-        File serverPath = wizard.getServerPath(serverId, NO_SERVER_TEXT);
-        serverPath.mkdirs();
-        File userDir = new File(System.getProperty("user.dir"));
-        if (Project.hasProject(userDir)) {
-            Project config = Project.loadProject(userDir);
-            if (config.isOpenmrsModule()) {
-                String artifactId = config.getArtifactId();
-                String groupId = config.getGroupId();
-                String version = config.getVersion();
-                if ((artifactId != null) && (groupId != null) && version != null) {
-                    getLog().info("OpenMRS module detected, installing before run...");
-                    ModuleInstall installer = new ModuleInstall(mavenProject, mavenSession, pluginManager);
-                    installer.installModule(serverPath.getName(), groupId, artifactId, version);
-                }
-            }
-        }
-        File tempDirectory = new File(serverPath, "tmp");
-        tempDirectory.mkdirs();
-        String warFile = null;
-        String h2File = null;
-        for(File file: serverPath.listFiles()) {
-            if (file.getName().startsWith("openmrs-") && (file.getName().endsWith(".war"))) {
-                warFile = file.getName();
-            }
-            else if (file.getName().startsWith("h2-") && (file.getName().endsWith(".jar"))) {
-                h2File = file.getName();
-            }
-            if ((warFile != null) && (h2File != null)) break;
-        };
-        // prepare web app configuration
-        List<Element> webAppConfiguration = new ArrayList<Element>();
-        webAppConfiguration.add(element("contextPath", "/openmrs"));
-        webAppConfiguration.add(element("tempDirectory", tempDirectory.getAbsolutePath()));
-        if (warFile == null) {
-            throw new MojoExecutionException("Error during running server: war file was not found");
-        }
-        // add h2 file to webapp config if it exists
-        if (h2File != null) {
-            webAppConfiguration.add(element("extraClasspath", new File(serverPath, h2File).getAbsolutePath()));
-        }
-        
-        List<Element> systemProperties = new ArrayList<Element>();
-        systemProperties.add(element("systemProperty",
-            element("name", "OPENMRS_INSTALLATION_SCRIPT"),
-            element("value", new File(serverPath, SDKConstants.OPENMRS_SERVER_PROPERTIES).getAbsolutePath())));
-        systemProperties.add(element("systemProperty",
-            element("name", "OPENMRS_APPLICATION_DATA_DIRECTORY"),
-            element("value", serverPath.getAbsolutePath() + File.separator )));
-    
-        List<Element> watchedProjects = getWatchedProjectsConfiguration(serverPath);
-        if (!watchedProjects.isEmpty()) {
-        	systemProperties.addAll(watchedProjects);
-        }
-        
-        executeMojo(
-                plugin(
-                        groupId(SDKConstants.PLUGIN_JETTY_GROUP_ID),
-                        artifactId(SDKConstants.PLUGIN_JETTY_ARTIFACT_ID),
-                        version(SDKConstants.PLUGIN_JETTY_VERSION)
-                ),
-                goal("deploy-war"),
-                configuration(
-                        element(name("war"), new File(serverPath, warFile).getAbsolutePath()),
-                        element(name("daemon"), "false"),
-                        element(name("webApp"), webAppConfiguration.toArray(new Element[0])),
-                        element(name("systemProperties"), systemProperties.toArray(new Element[0]))
-                ),
-                executionEnvironment(mavenProject, mavenSession, pluginManager)
-        );
-    }
+	/**
+	 * The Maven BuildPluginManager component.
+	 *
+	 * @component
+	 * @required
+	 */
+	private BuildPluginManager pluginManager;
 
-	private List<Element> getWatchedProjectsConfiguration(File serverPath) throws MojoExecutionException {
-	    Server serverConfig = Server.loadServer(serverPath);
-        List<Element> watched = new ArrayList<Element>();
-        Set<Project> watchedProjects = serverConfig.getWatchedProjects();
-        if (!watchedProjects.isEmpty()) {
-        	getLog().info(" ");
-        	getLog().info("Hot redeployment for controllers and gsps enabled.");
-        	
-        	getLog().info(" ");
+	/**
+	 * @component
+	 * @required
+	 */
+	private Wizard wizard;
 
-	        for (Project project : watchedProjects) {
-		        watched.add(element("systemProperty", element("name", "uiFramework.development." + project.getArtifactId()),
-		        	element("value", project.getPath())));
-	        }
-        }
-        
-        return watched;
-    }
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		if (serverId == null) {
+			File currentProperties = wizard.getCurrentServerPath();
+			if (currentProperties != null) serverId = currentProperties.getName();
+		}
+		serverId = wizard.promptForExistingServerIdIfMissing(serverId);
+		Server server = Server.loadServer(serverId);
+		File serverPath = server.getServerDirectory();
+		serverPath.mkdirs();
+		File userDir = new File(System.getProperty("user.dir"));
+		if (Project.hasProject(userDir)) {
+			Project config = Project.loadProject(userDir);
+			if (config.isOpenmrsModule()) {
+				String artifactId = config.getArtifactId();
+				String groupId = config.getGroupId();
+				String version = config.getVersion();
+				if ((artifactId != null) && (groupId != null) && version != null) {
+					getLog().info("OpenMRS module detected, installing before run...");
+					ModuleInstall installer = new ModuleInstall(mavenProject, mavenSession, pluginManager);
+					installer.installModule(serverPath.getName(), groupId, artifactId, version);
+				}
+			}
+		}
+
+		if (Boolean.FALSE.equals(fork)) {
+			new RunTomcat(serverId, port, wizard).execute();
+		} else {
+			runInFork(server);
+		}
+	}
+
+	private void runInFork(Server server) throws MojoExecutionException, MojoFailureException {
+		String maven = "mvn";
+		if (System.getProperty("os.name").toLowerCase(Locale.ENGLISH).contains("windows")) {
+			maven = "mvn.bat";
+		}
+
+		if (server.hasWatchedProjects()) {
+			File serversPath = Server.getDefaultServersPath();
+			File springloadedJar = new File(serversPath, "springloaded.jar");
+			if (!springloadedJar.exists()) {
+				Artifact artifact = new Artifact("springloaded", "1.2.5.RELEASE", "org.springframework", "jar");
+				artifact.setDestFileName("springloaded.jar");
+				executeMojo(
+						plugin(
+								groupId(SDKConstants.PLUGIN_DEPENDENCIES_GROUP_ID),
+								artifactId(SDKConstants.PLUGIN_DEPENDENCIES_ARTIFACT_ID),
+								version(SDKConstants.PLUGIN_DEPENDENCIES_VERSION)
+						),
+						goal("copy"),
+						configuration(
+								element(name("artifactItems"), artifact.toElement(serversPath.getAbsolutePath()))
+						),
+						executionEnvironment(mavenProject, mavenSession, pluginManager)
+				);
+			}
+		}
+
+		String mavenOpts = System.getProperty("MAVEN_OPTS", "");
+		if (!mavenOpts.contains("-Xmx")) {
+			mavenOpts += " -Xmx1536m";
+		}
+		if (!mavenOpts.contains("-XX:MaxPermSize=")) {
+			mavenOpts += " -XX:MaxPermSize=1024m";
+		}
+		if (server.hasWatchedProjects()) {
+			mavenOpts += " -javaagent:" + new File(Server.getDefaultServersPath(), "springloaded.jar").getAbsolutePath() + " -noverify";
+		}
+
+		if (debug != null) {
+			String address = "1044";
+			if (StringUtils.isNumeric(debug)) {
+				address = debug;
+			}
+			mavenOpts += " -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=" + address;
+
+			System.out.println("\nConnect remote debugger with port " + address + "\n");
+		}
+
+		System.setProperty("MAVEN_OPTS", mavenOpts);
+
+		System.out.println("Using JAVA_HOME: " + System.getenv("JAVA_HOME") + "\n");
+		System.out.println("Using MAVEN_OPTS: " + mavenOpts + "\n");
+
+		System.out.println("Forking a new process... (use -Dfork=false to prevent forking)\n");
+
+		List<String> commands = new ArrayList<String>();
+		commands.add(maven);
+		commands.add(SDKConstants.getSDKInfo().getGroupId() + ":"
+				+ SDKConstants.getSDKInfo().getArtifactId() + ":" + SDKConstants.getSDKInfo().getVersion() + ":run-tomcat");
+		commands.add("-DserverId=" + server.getServerId());
+		if (port != null) {
+			commands.add("-Dport=" + port);
+		}
+		if (server.hasWatchedProjects()) {
+			commands.add("-Dspringloaded=inclusions=org.openmrs..*");
+		}
+
+		ProcessBuilder processBuilder = new ProcessBuilder(commands);
+		processBuilder.redirectErrorStream(true);
+		processBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+		processBuilder.redirectInput(ProcessBuilder.Redirect.INHERIT);
+		try {
+			final Process process = processBuilder.start();
+
+			Runtime.getRuntime().addShutdownHook(new Thread() {
+				@Override
+				public void run() {
+					process.destroy();
+				}
+			});
+
+			process.waitFor();
+		} catch (IOException e) {
+			throw new MojoFailureException("Failed to start Tomcat process", e);
+		} catch (InterruptedException e) {
+			throw new MojoFailureException("Interrupted waiting for Tomcat process", e);
+		}
+	}
 }

--- a/src/main/java/org/openmrs/maven/plugins/RunTomcat.java
+++ b/src/main/java/org/openmrs/maven/plugins/RunTomcat.java
@@ -1,0 +1,129 @@
+package org.openmrs.maven.plugins;
+
+import org.apache.catalina.Context;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.loader.WebappLoader;
+import org.apache.catalina.startup.Tomcat;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.realm.DuplicateRealmException;
+import org.openmrs.maven.plugins.model.Server;
+import org.openmrs.maven.plugins.utility.Project;
+import org.openmrs.maven.plugins.utility.SDKConstants;
+import org.openmrs.maven.plugins.utility.Wizard;
+
+import java.io.File;
+import java.util.Set;
+
+/**
+ * @goal run-tomcat
+ * @requiresProject false
+ */
+public class RunTomcat extends AbstractMojo {
+
+	/**
+	 * @parameter expression="${serverId}"
+	 */
+	private String serverId;
+
+	/**
+	 * @parameter expression="${port}"
+	 */
+	private Integer port;
+
+	/**
+	 * @component
+	 * @required
+	 */
+	private Wizard wizard;
+
+	public RunTomcat() {
+	}
+
+	public RunTomcat(String serverId, Integer port, Wizard wizard) {
+		this.serverId = serverId;
+		this.port = port;
+		this.wizard = wizard;
+	}
+
+	@Override
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		serverId = wizard.promptForExistingServerIdIfMissing(serverId);
+		Server server = Server.loadServer(serverId);
+		File serverPath = server.getServerDirectory();
+		File tempDirectory = new File(serverPath, "tmp");
+		tempDirectory.mkdirs();
+
+		String warFile = "openmrs.war";
+		for (File file : serverPath.listFiles()) {
+			if ((file.getName().endsWith(".war"))) {
+				warFile = file.getName();
+				break;
+			}
+		}
+
+		Tomcat tomcat = new Tomcat();
+		if (port == null) {
+			port = 8080;
+		}
+		tomcat.setPort(port);
+		tomcat.setBaseDir(tempDirectory.getAbsolutePath());
+		tomcat.getHost().setAppBase(tempDirectory.getAbsolutePath());
+		tomcat.getHost().setAutoDeploy(true);
+		tomcat.getHost().setDeployOnStartup(true);
+		Context context = tomcat.addWebapp(tomcat.getHost(), "/openmrs", new File(serverPath, warFile).getAbsolutePath());
+
+		System.setProperty("OPENMRS_INSTALLATION_SCRIPT",
+				new File(serverPath, SDKConstants.OPENMRS_SERVER_PROPERTIES).getAbsolutePath());
+		System.setProperty("OPENMRS_APPLICATION_DATA_DIRECTORY", serverPath.getAbsolutePath() + File.separator);
+
+		setSystemPropertiesForWatchedProjects(serverPath);
+
+		ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+		try {
+			Thread.currentThread().setContextClassLoader(newTomcatClassLoader());
+			WebappLoader tomcatLoader = new WebappLoader(Thread.currentThread().getContextClassLoader());
+			context.setLoader(tomcatLoader);
+
+			tomcat.start();
+			tomcat.getServer().await();
+		} catch (LifecycleException e) {
+			throw new MojoExecutionException("Tomcat failed to start", e);
+		} finally {
+			Thread.currentThread().setContextClassLoader(originalClassLoader);
+		}
+	}
+
+	protected ClassRealm newTomcatClassLoader() throws MojoExecutionException {
+		try {
+			ClassWorld world = new ClassWorld();
+			ClassRealm root = world.newRealm("tomcat", Thread.currentThread().getContextClassLoader());
+
+			return root;
+		} catch (DuplicateRealmException e) {
+			throw new MojoExecutionException(e.getMessage(), e);
+		}
+	}
+
+	private void setSystemPropertiesForWatchedProjects(File serverPath) throws MojoExecutionException {
+		Server serverConfig = Server.loadServer(serverPath);
+		Set<Project> watchedProjects = serverConfig.getWatchedProjects();
+		if (!watchedProjects.isEmpty()) {
+			getLog().info(" ");
+			getLog().info("Hot redeployment enabled for: ");
+			int i = 1;
+			for (Project project : watchedProjects) {
+				System.setProperty("uiFramework.development." + project.getArtifactId(), project.getPath());
+				System.setProperty(project.getArtifactId() + ".development.directory", project.getPath());
+				getLog().info(
+						String.format("%d) %s:%s at %s", i, project.getGroupId(), project.getArtifactId(), project.getPath()));
+				i++;
+			}
+			getLog().info(" ");
+		}
+	}
+
+}

--- a/src/main/java/org/openmrs/maven/plugins/Unwatch.java
+++ b/src/main/java/org/openmrs/maven/plugins/Unwatch.java
@@ -42,8 +42,8 @@ public class Unwatch extends AbstractMojo {
 
 	@Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-	    File serverPath = wizard.getServerPath(serverId);
-	    Server serverConfig = Server.loadServer(serverPath);
+	    serverId = wizard.promptForExistingServerIdIfMissing(serverId);
+	    Server serverConfig = Server.loadServer(serverId);
 	    
 	    File userDir = new File(System.getProperty("user.dir"));
 	    if (StringUtils.isBlank(artifactId) && Project.hasProject(userDir)) {

--- a/src/main/java/org/openmrs/maven/plugins/UpgradePlatform.java
+++ b/src/main/java/org/openmrs/maven/plugins/UpgradePlatform.java
@@ -109,8 +109,9 @@ public class UpgradePlatform extends AbstractMojo{
             if (currentProperties != null) serverId = currentProperties.getName();
         }
         resultVersion = wizard.promptForValueIfMissing(version, "version");
-
-        File serverPath = wizard.getServerPath(serverId);
+        serverId = wizard.promptForExistingServerIdIfMissing(serverId);
+        Server server = Server.loadServer(serverId);
+        File serverPath = server.getServerDirectory();
         resultServer = serverPath.getName();
         Server properties = Server.loadServer(serverPath);
         String webapp = properties.getParam(Server.PROPERTY_VERSION);
@@ -206,7 +207,7 @@ public class UpgradePlatform extends AbstractMojo{
         // also remove copy of old properties file if success
         listFilesToRemove.add(tempProperties);
         boolean addDemoData = (String.valueOf(true).equals(properties.getParam(Server.PROPERTY_DEMO_DATA)));
-        Server server = new Server.ServerBuilder()
+        server = new Server.ServerBuilder()
                 .setServerId(resultServer)
                 .setVersion(resultVersion)
                 .setDbDriver(properties.getParam(Server.PROPERTY_DB_DRIVER))

--- a/src/main/java/org/openmrs/maven/plugins/Watch.java
+++ b/src/main/java/org/openmrs/maven/plugins/Watch.java
@@ -30,13 +30,13 @@ public class Watch extends AbstractMojo {
 
 	@Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-	    File serverPath = wizard.getServerPath(serverId);
+	    serverId = wizard.promptForExistingServerIdIfMissing(serverId);
 	    
 	    File userDir = new File(System.getProperty("user.dir"));
 	    if (Project.hasProject(userDir)) {
             Project config = Project.loadProject(userDir);
             
-            Server serverConfig = Server.loadServer(serverPath);
+            Server serverConfig = Server.loadServer(serverId);
             serverConfig.addWatchedProject(config);
             serverConfig.save();
             

--- a/src/main/java/org/openmrs/maven/plugins/model/Server.java
+++ b/src/main/java/org/openmrs/maven/plugins/model/Server.java
@@ -122,8 +122,11 @@ public class Server {
         properties = new Properties();
     };
 
-    private Server(File file, Properties properties){
-        this.propertiesFile = file;
+    private Server(File file, Properties properties) {
+        if (file != null) {
+            this.propertiesFile = new File(file, SDKConstants.OPENMRS_SERVER_PROPERTIES);
+            this.serverDirectory = file;
+        }
         this.properties = properties;
     }
 
@@ -138,9 +141,13 @@ public class Server {
 
     public static Server createServer(File dir) {
         Properties properties = new Properties();
-        File config = new File(dir, SDKConstants.OPENMRS_SERVER_PROPERTIES);
+        return new Server(dir, properties);
+    }
 
-        return new Server(config, properties);
+    public static Server loadServer(String serverId) throws MojoExecutionException {
+        File serversPath = getDefaultServersPath();
+        File serverPath = new File(serversPath, serverId);
+        return loadServer(serverPath);
     }
 
     public static Server loadServer(File dir) throws MojoExecutionException {
@@ -164,7 +171,7 @@ public class Server {
             IOUtils.closeQuietly(in);
         }
 
-        return new Server(config, properties);
+        return new Server(dir, properties);
     }
 
     public static Server loadConfig(File dir) throws MojoExecutionException {
@@ -253,6 +260,10 @@ public class Server {
             watchedProjects.add(project);
         }
         return watchedProjects;
+    }
+
+    public boolean hasWatchedProjects() {
+        return !getWatchedProjects().isEmpty();
     }
 
     public static File getDefaultServersPath(){

--- a/src/main/java/org/openmrs/maven/plugins/utility/DefaultWizard.java
+++ b/src/main/java/org/openmrs/maven/plugins/utility/DefaultWizard.java
@@ -210,19 +210,18 @@ public class DefaultWizard implements Wizard {
      * @throws MojoFailureException
      */
     @Override
-    public File getServerPath(String serverId, String failureMessage) throws MojoFailureException {
+    public String promptForExistingServerIdIfMissing(String serverId) {
         File omrsHome = new File(System.getProperty("user.home"), SDKConstants.OPENMRS_SERVER_PATH);
-        String resultServerId = null;
         List<String> servers = getListOf5RecentServers();
-        resultServerId = promptForValueWithDefaultList(serverId, "serverId", servers);
-        if (resultServerId.equals(NONE)) {
-            throw new MojoFailureException(INVALID_SERVER);
+        serverId = promptForValueWithDefaultList(serverId, "serverId", servers);
+        if (serverId.equals(NONE)) {
+            throw new RuntimeException(INVALID_SERVER);
         }
-        File serverPath = new File(omrsHome, resultServerId);
+        File serverPath = new File(omrsHome, serverId);
         if (!serverPath.exists()) {
-            throw new MojoFailureException(failureMessage);
+            throw new RuntimeException("There is no server with the given server id. Please create it first using openmrs-sdk:setup.");
         }
-        return serverPath;
+        return serverId;
     }
 
     @Override
@@ -336,17 +335,6 @@ public class DefaultWizard implements Wizard {
             if (properties.getParam(Server.PROPERTY_SERVER_ID) != null) return propertiesFile.getParentFile();
         }
         return null;
-    }
-
-    /**
-     * Get server with default failure message
-     * @param serverId
-     * @return
-     * @throws MojoFailureException
-     */
-    @Override
-    public File getServerPath(String serverId) throws MojoFailureException {
-        return getServerPath(serverId, DEFAULT_FAIL_MESSAGE);
     }
 
     /**

--- a/src/main/java/org/openmrs/maven/plugins/utility/SDKConstants.java
+++ b/src/main/java/org/openmrs/maven/plugins/utility/SDKConstants.java
@@ -1,11 +1,15 @@
 package org.openmrs.maven.plugins.utility;
 
+import org.apache.commons.io.IOUtils;
 import org.openmrs.maven.plugins.model.Artifact;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * Class for handling static values
@@ -203,7 +207,6 @@ public class SDKConstants {
         if (webAppVersion == null) return null;
         return new ArrayList<Artifact>() {{
             add(new Artifact("openmrs-webapp", webAppVersion, Artifact.GROUP_WEB, Artifact.TYPE_WAR));
-            add(new Artifact("h2", "1.4.190", Artifact.GROUP_H2, Artifact.TYPE_JAR));
         }};
     }
 
@@ -214,5 +217,20 @@ public class SDKConstants {
      */
     public static Artifact getReferenceModule(String version) {
         return new Artifact("referenceapplication-package", version, Artifact.GROUP_DISTRO, Artifact.TYPE_ZIP).putClassifier("distro");
+    }
+
+    public static Artifact getSDKInfo() {
+    	Properties properties = new Properties();
+    	InputStream in = SDKConstants.class.getClassLoader().getResourceAsStream("sdk.properties");
+    	try {
+			properties.load(in);
+			in.close();
+			return new Artifact(properties.getProperty("artifactId"), properties.getProperty("version"), properties.getProperty("groupId"));
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		} finally {
+			IOUtils.closeQuietly(in);
+		}
     }
 }

--- a/src/main/java/org/openmrs/maven/plugins/utility/Wizard.java
+++ b/src/main/java/org/openmrs/maven/plugins/utility/Wizard.java
@@ -37,11 +37,9 @@ public interface Wizard {
 
     boolean checkYes(String value);
 
-    File getServerPath(String serverId, String failureMessage) throws MojoFailureException;
-
     File getCurrentServerPath() throws MojoExecutionException;
 
-    File getServerPath(String serverId) throws MojoFailureException;
+    String promptForExistingServerIdIfMissing(String serverId);
 
     List<String> getListOf5RecentServers();
 

--- a/src/main/resources/sdk.properties
+++ b/src/main/resources/sdk.properties
@@ -1,0 +1,3 @@
+groupId=${groupId}
+artifactId=${artifactId}
+version=${version}


### PR DESCRIPTION
The pull request introduces the following changes:
- Changes container from Jetty to Tomcat
- Container is by default started in a forked process when calling openmrs-sdk:run, it gives us control over jvm settings such as memory, remote debug mode, springloaded agent and more...
- You can disable forking by setting -Dfork=false
