### PR TITLE
AbstractTask constructor bug fix

### DIFF
--- a/src/main/java/org/openmrs/maven/plugins/AbstractTask.java
+++ b/src/main/java/org/openmrs/maven/plugins/AbstractTask.java
@@ -81,6 +81,10 @@ public abstract class AbstractTask extends AbstractMojo {
         this.artifactMetadataSource = other.artifactMetadataSource;
         this.moduleInstaller = other.moduleInstaller;
         this.versionsHelper = other.versionsHelper;
+        initUtilities();
+    }
+
+    public void initUtilities() {
         if(versionsHelper == null){
             versionsHelper = new VersionsHelper(artifactFactory, mavenProject, mavenSession, artifactMetadataSource);
         }

--- a/src/main/java/org/openmrs/maven/plugins/ModuleInstall.java
+++ b/src/main/java/org/openmrs/maven/plugins/ModuleInstall.java
@@ -62,6 +62,7 @@ public class ModuleInstall extends AbstractTask {
     }
 
     public void execute() throws MojoExecutionException, MojoFailureException {
+        initUtilities();
         installModule(serverId, groupId, artifactId, version);
     }
 

--- a/src/main/java/org/openmrs/maven/plugins/Reset.java
+++ b/src/main/java/org/openmrs/maven/plugins/Reset.java
@@ -31,6 +31,7 @@ public class Reset extends AbstractTask {
     private String full;
 
     public void execute() throws MojoExecutionException, MojoFailureException {
+        initUtilities();
         if (serverId == null) {
             File currentProperties = wizard.getCurrentServerPath();
             if (currentProperties != null) serverId = currentProperties.getName();

--- a/src/main/java/org/openmrs/maven/plugins/Run.java
+++ b/src/main/java/org/openmrs/maven/plugins/Run.java
@@ -50,6 +50,7 @@ public class Run extends AbstractTask {
 
 
 	public void execute() throws MojoExecutionException, MojoFailureException {
+        initUtilities();
 		if (serverId == null) {
 			File currentProperties = wizard.getCurrentServerPath();
 			if (currentProperties != null) serverId = currentProperties.getName();

--- a/src/main/java/org/openmrs/maven/plugins/Setup.java
+++ b/src/main/java/org/openmrs/maven/plugins/Setup.java
@@ -144,7 +144,7 @@ public class Setup extends AbstractTask {
                     wizard.showMessage("The specified database "+server.getDbName()+" does not exist and it will be created for you.");
                 }
             } else {
-                moduleManager.installModule(SDKConstants.H2_ARTIFACT, server.getServerDirectory().getPath());
+                moduleInstaller.installModule(SDKConstants.H2_ARTIFACT, server.getServerDirectory().getPath());
                 wizard.showMessage("The specified database "+server.getDbName()+" does not exist and it will be created for you.");
             }
         }
@@ -261,6 +261,7 @@ public class Setup extends AbstractTask {
     }
 
     public void execute() throws MojoExecutionException, MojoFailureException {
+        initUtilities();
         boolean createPlatform;
         String version = null;
         if(platform == null && distro == null){

--- a/src/main/java/org/openmrs/maven/plugins/Upgrade.java
+++ b/src/main/java/org/openmrs/maven/plugins/Upgrade.java
@@ -28,6 +28,7 @@ public class Upgrade extends AbstractTask {
     private String version;
 
     public void execute() throws MojoExecutionException, MojoFailureException {
+        initUtilities();
         UpgradePlatform upgrader = new UpgradePlatform(this);
         upgrader.upgradeServer(serverId, version, false);
         getLog().info(String.format(TEMPLATE_SUCCESS, serverId, version));

--- a/src/main/java/org/openmrs/maven/plugins/UpgradePlatform.java
+++ b/src/main/java/org/openmrs/maven/plugins/UpgradePlatform.java
@@ -48,6 +48,7 @@ public class UpgradePlatform extends AbstractTask {
     private String version;
 
     public void execute() throws MojoExecutionException, MojoFailureException {
+        initUtilities();
         upgradeServer(serverId, version, true);
     }
 


### PR DESCRIPTION
Default AbstractTask constructor didn't initialize VersionsHelper nor ModuleInstaller, so there were NullPointerExceptions occuring. This commit adds `initUtilities` method to AbstractTask, which is invoked at beginning of every execute method, to make sure that utitlities are initialized.
