### PR TITLE
SDK-94 Support distro development

### DIFF
--- a/src/main/java/org/openmrs/maven/plugins/AbstractTask.java
+++ b/src/main/java/org/openmrs/maven/plugins/AbstractTask.java
@@ -6,6 +6,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.project.MavenProject;
+import org.openmrs.maven.plugins.utility.DistroHelper;
 import org.openmrs.maven.plugins.utility.ModuleInstaller;
 import org.openmrs.maven.plugins.utility.VersionsHelper;
 import org.openmrs.maven.plugins.utility.Wizard;
@@ -66,9 +67,14 @@ public abstract class AbstractTask extends AbstractMojo {
     VersionsHelper versionsHelper;
 
     /**
-     *
+     * handles installing modules on server
      */
     ModuleInstaller moduleInstaller;
+
+    /**
+     * handles distro-properties
+     */
+    DistroHelper distroHelper;
 
     public AbstractTask(){}
 
@@ -81,6 +87,7 @@ public abstract class AbstractTask extends AbstractMojo {
         this.artifactMetadataSource = other.artifactMetadataSource;
         this.moduleInstaller = other.moduleInstaller;
         this.versionsHelper = other.versionsHelper;
+        this.distroHelper = other.distroHelper;
         initUtilities();
     }
 
@@ -90,6 +97,9 @@ public abstract class AbstractTask extends AbstractMojo {
         }
         if(moduleInstaller==null){
             moduleInstaller = new ModuleInstaller(mavenProject, mavenSession, pluginManager, versionsHelper);
+        }
+        if(distroHelper == null){
+            distroHelper = new DistroHelper(mavenProject, mavenSession, pluginManager);
         }
     }
 }

--- a/src/main/java/org/openmrs/maven/plugins/Reset.java
+++ b/src/main/java/org/openmrs/maven/plugins/Reset.java
@@ -3,6 +3,7 @@ package org.openmrs.maven.plugins;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.openmrs.maven.plugins.model.Artifact;
 import org.openmrs.maven.plugins.model.Server;
 import org.openmrs.maven.plugins.utility.DBConnector;
 import org.openmrs.maven.plugins.utility.SDKConstants;
@@ -10,6 +11,7 @@ import org.openmrs.maven.plugins.utility.SDKConstants;
 import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.List;
 
 /**
  * @goal reset
@@ -37,14 +39,14 @@ public class Reset extends AbstractTask {
             if (currentProperties != null) serverId = currentProperties.getName();
         }
         serverId = wizard.promptForExistingServerIdIfMissing(serverId);
-        Server properties = Server.loadServer(serverId);
+        Server server = Server.loadServer(serverId);
         DBConnector connector = null;
         try {
             String dbName = String.format(SDKConstants.DB_NAME_TEMPLATE, serverId);
-            String uri = properties.getParam(Server.PROPERTY_DB_URI);
+            String uri = server.getParam(Server.PROPERTY_DB_URI);
             uri = uri.substring(0, uri.lastIndexOf("/"));
-            connector = new DBConnector(uri, properties.getParam(Server.PROPERTY_DB_USER),
-                                          properties.getParam(Server.PROPERTY_DB_PASS),
+            connector = new DBConnector(uri, server.getParam(Server.PROPERTY_DB_USER),
+                                          server.getParam(Server.PROPERTY_DB_PASS),
                                           dbName);
             connector.dropDatabase();
             connector.close();
@@ -57,34 +59,84 @@ public class Reset extends AbstractTask {
                 getLog().error(e.getMessage());
             }
         }
-        boolean isPlatform = properties.getParam(Server.PROPERTY_VERSION) == null;
-        Server server = new Server.ServerBuilder()
-                .setServerId(properties.getParam(Server.PROPERTY_SERVER_ID))
-                .setVersion(properties.getParam(Server.PROPERTY_PLATFORM))
-                .setDbDriver(properties.getParam(Server.PROPERTY_DB_DRIVER))
-                .setDbUri(properties.getParam(Server.PROPERTY_DB_URI))
-                .setDbUser(properties.getParam(Server.PROPERTY_DB_USER))
-                .setDbPassword(properties.getParam(Server.PROPERTY_DB_PASS))
-                .setInteractiveMode("false")
-                .build();
+        boolean isPlatform = server.getParam(Server.PROPERTY_VERSION) == null;
         if (wizard.checkYes(full)) {
             try {
-                Setup platform = new Setup(this);
-                FileUtils.deleteDirectory(server.getServerDirectory());
-                platform.setup(server, isPlatform, true, null);
-                getLog().info(String.format(TEMPLATE_SUCCESS_FULL, server.getServerId()));
+                Server newServer = new Server.ServerBuilder()
+                        .setServerId(server.getParam(Server.PROPERTY_SERVER_ID))
+                        .setVersion(server.getParam(Server.PROPERTY_PLATFORM))
+                        .setDbDriver(server.getParam(Server.PROPERTY_DB_DRIVER))
+                        .setDbUri(server.getParam(Server.PROPERTY_DB_URI))
+                        .setDbUser(server.getParam(Server.PROPERTY_DB_USER))
+                        .setDbPassword(server.getParam(Server.PROPERTY_DB_PASS))
+                        .setInteractiveMode("false")
+                        .build();
+                Setup setup = new Setup(this);
+                FileUtils.deleteDirectory(newServer.getServerDirectory());
+                setup.setup(newServer, isPlatform, true, null);
+                getLog().info(String.format(TEMPLATE_SUCCESS_FULL, newServer.getServerId()));
             } catch (IOException e) {
                 throw new MojoExecutionException(e.getMessage());
             }
         }
         else {
-	        ServerUpgrader serverUpgrader = new ServerUpgrader(this);
 	        if(isPlatform){
+                ServerUpgrader serverUpgrader = new ServerUpgrader(this);
 		        serverUpgrader.upgradePlatform(server, server.getVersion());
 	        } else {
-		        serverUpgrader.upgradeToDistro(server);
+		        resetDistro(server);
 	        }
             getLog().info(String.format(TEMPLATE_SUCCESS, server.getServerId()));
         }
+    }
+
+    public void resetDistro(Server server) throws MojoExecutionException, MojoFailureException {
+        Setup setup = new Setup(this);
+        //delete webapp and modules of existing server version, leave out modules installed by user
+        List<Artifact> userModules = server.getUserModules();
+        if(server.getDbDriver().equals(SDKConstants.DRIVER_H2)){
+            userModules.add(SDKConstants.H2_ARTIFACT);
+        }
+        File modulesFolder = new File(server.getServerDirectory(), SDKConstants.OPENMRS_SERVER_MODULES);
+        deleteNonUserModulesFromDir(userModules, server.getServerDirectory());
+        deleteNonUserModulesFromDir(userModules, modulesFolder);
+        //delete installation.properties file on server to avoid Setup task errors with already existing server
+        server.saveBackupProperties();
+        server.delete();
+        setup.setup(server, false, true, null);
+        server.deleteBackupProperties();
+        getLog().info("Server reset successful");
+    }
+
+    private void deleteNonUserModulesFromDir(List<Artifact> userModules, File dir) {
+        File[] files = dir.listFiles();
+        if(files != null){
+            for (File f: files) {
+                String type = f.getName().substring(f.getName().lastIndexOf(".") + 1);
+                if (SDKConstants.isExtensionSupported(type)) {
+                    boolean toDelete = true;
+                    String id = getId(f.getName());
+                    for(Artifact userModule : userModules){
+                        if(userModule.getArtifactId().equals(id)){
+                            toDelete = false;
+                            break;
+                        }
+                    }
+                    if(toDelete){
+                        f.delete();
+                    }
+                }
+            }
+        }
+    }
+    /**
+     * Get artifact id from module name (without -omod, etc)
+     * @param name of file which id will be obtained
+     * @return
+     */
+    public String getId(String name) {
+        int index = name.indexOf('-');
+        if (index == -1) return name;
+        return name.substring(0, index);
     }
 }

--- a/src/main/java/org/openmrs/maven/plugins/model/Artifact.java
+++ b/src/main/java/org/openmrs/maven/plugins/model/Artifact.java
@@ -1,5 +1,7 @@
 package org.openmrs.maven.plugins.model;
 
+import com.google.common.base.Objects;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,7 +31,7 @@ public class Artifact {
     public static final String TYPE_ZIP = "zip";
     public static final String DEST_TEMPLATE = "%s-%s.%s";
 
-    public Artifact() {};
+    public Artifact() {}
 
     /**
      * Constructor if type is not set, and groupId is default
@@ -141,5 +143,20 @@ public class Artifact {
         attributes.add(element("outputDirectory", outputDir));
         Element[] arrayElements = attributes.toArray(new Element[0]);
         return element("artifactItem", arrayElements);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Artifact artifact = (Artifact) o;
+        return Objects.equal(version, artifact.version) &&
+                Objects.equal(groupId, artifact.groupId) &&
+                Objects.equal(artifactId, artifact.artifactId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(version, groupId, artifactId);
     }
 }

--- a/src/main/java/org/openmrs/maven/plugins/model/DistroProperties.java
+++ b/src/main/java/org/openmrs/maven/plugins/model/DistroProperties.java
@@ -43,13 +43,9 @@ public class DistroProperties {
         this.properties = properties;
     }
 
-    public DistroProperties(File file){
+    public DistroProperties(File file) throws MojoExecutionException{
         this.properties = new Properties();
-        try {
-            loadPropertiesFromFile(file);
-        } catch (MojoExecutionException e) {
-            e.printStackTrace();
-        }
+        loadPropertiesFromFile(file);
     }
 
     private String createFileName(String version){

--- a/src/main/java/org/openmrs/maven/plugins/model/UpgradeDifferential.java
+++ b/src/main/java/org/openmrs/maven/plugins/model/UpgradeDifferential.java
@@ -1,0 +1,54 @@
+package org.openmrs.maven.plugins.model;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Basic wrapper for list and map of artifacts
+ */
+public class UpgradeDifferential {
+    private final List<Artifact> modulesToAdd = new ArrayList<Artifact>();
+    private final Map<Artifact, Artifact> updateOldToNewMap = new HashMap<Artifact,Artifact>();
+    private Artifact platformArtifact;
+
+    public boolean isEmpty(){
+        return platformArtifact ==null&& updateOldToNewMap.isEmpty()&&modulesToAdd.isEmpty();
+    }
+
+    public Artifact getPlatformArtifact() {
+        return platformArtifact;
+    }
+
+    public void setPlatformArtifact(Artifact platformArtifact) {
+        this.platformArtifact = platformArtifact;
+    }
+
+    public List<Artifact> getModulesToAdd() {
+        return modulesToAdd;
+    }
+
+    /**
+     * IMPORTANT: convention is: key is old version artifact, value is new version artifact
+     */
+    public Map<Artifact, Artifact> getUpdateOldToNewMap() {
+        return updateOldToNewMap;
+    }
+
+    public boolean addModuleToAdd(Artifact artifact) {
+        return modulesToAdd.add(artifact);
+    }
+
+    public boolean removeModuleToAdd(Object o) {
+        return modulesToAdd.remove(o);
+    }
+
+    public Artifact putUpdateEntry(Artifact oldVersionArtifact, Artifact newVersionArtifact) {
+        return updateOldToNewMap.put(oldVersionArtifact, newVersionArtifact);
+    }
+
+    public Artifact removeUpdateEntry(Object oldVersionArtifact) {
+        return updateOldToNewMap.remove(oldVersionArtifact);
+    }
+}

--- a/src/main/java/org/openmrs/maven/plugins/model/Version.java
+++ b/src/main/java/org/openmrs/maven/plugins/model/Version.java
@@ -34,4 +34,7 @@ public class Version extends DefaultArtifactVersion {
         }
         else return parts[parts.length - 1];
     }
+    public boolean isSnapshot(){
+        return getQualifier()!= null && getQualifier().contains("SNAPSHOT");
+    }
 }

--- a/src/main/java/org/openmrs/maven/plugins/utility/ModuleInstaller.java
+++ b/src/main/java/org/openmrs/maven/plugins/utility/ModuleInstaller.java
@@ -97,56 +97,6 @@ public class ModuleInstaller {
         prepareModule(artifact, outputDir, goal);
     }
 
-    public DistroProperties downloadDistroProperties(File serverPath, Server server) throws MojoExecutionException {
-
-        Artifact artifact = new Artifact(server.getDistroArtifactId(), server.getVersion(), server.getDistroGroupId(), "jar");
-        artifact.setDestFileName("openmrs-distro.jar");
-        List<Element> artifactItems = new ArrayList<Element>();
-        Element element = artifact.toElement(serverPath.toString());
-        artifactItems.add(element);
-
-        executeMojo(
-                plugin(
-                        groupId(SDKConstants.PLUGIN_DEPENDENCIES_GROUP_ID),
-                        artifactId(SDKConstants.PLUGIN_DEPENDENCIES_ARTIFACT_ID),
-                        version(SDKConstants.PLUGIN_DEPENDENCIES_VERSION)
-                ),
-                goal("copy"),
-                configuration(
-                        element(name("artifactItems"), artifactItems.toArray(new Element[0]))
-                ),
-                executionEnvironment(mavenProject, mavenSession, pluginManager)
-        );
-
-        DistroProperties distroProperties = null;
-        File file = new File(serverPath, artifact.getDestFileName());
-        ZipFile zipFile = null;
-        try {
-            zipFile = new ZipFile(file);
-
-            Enumeration<? extends ZipEntry> entries = zipFile.entries();
-
-            while(entries.hasMoreElements()){
-                ZipEntry zipEntry = entries.nextElement();
-                if("openmrs-distro.properties".equals(zipEntry.getName())){
-                    Properties properties = new Properties();
-                    properties.load(zipFile.getInputStream(zipEntry));
-                    distroProperties = new DistroProperties(properties);
-                }
-            }
-
-            zipFile.close();
-
-
-        } catch (IOException e) {
-            throw new RuntimeException("Could not read " + file.toString(), e);
-        } finally {
-            IOUtils.closeQuietly(zipFile);
-        }
-
-        return distroProperties;
-    }
-
     /**
      * Extract selected Artifact list
      * @param artifacts

--- a/src/main/java/org/openmrs/maven/plugins/utility/SDKConstants.java
+++ b/src/main/java/org/openmrs/maven/plugins/utility/SDKConstants.java
@@ -66,7 +66,8 @@ public class SDKConstants {
     public static final String SETUP_DEFAULT_PLATFORM_VERSION = "1.11.5";
 
     public static final String REFERENCEAPPLICATION_ARTIFACT_ID = "referenceapplication-package";
-    public static final List<String> SUPPPORTED_OLD_REFAPP_VERSIONS = java.util.Arrays.asList("2.1", "2.2", "2.3.1");
+    public static final List<String> SUPPPORTED_REFAPP_VERSIONS_2_3_1_OR_LOWER = java.util.Arrays.asList("2.1", "2.2", "2.3.1");
+    private final static String[] SUPPORTED_MODULE_EXTENSIONS = new String[]{Artifact.TYPE_WAR, Artifact.TYPE_JAR, Artifact.TYPE_OMOD};
 
     // modules 2.x
     public static final List<Artifact> ARTIFACTS_2_0 = new ArrayList<Artifact>() {{
@@ -239,5 +240,10 @@ public class SDKConstants {
 		} finally {
 			IOUtils.closeQuietly(in);
 		}
+    }
+    public static boolean isExtensionSupported(String type) {
+        return type.equals(SUPPORTED_MODULE_EXTENSIONS[0])
+                || type.equals(SUPPORTED_MODULE_EXTENSIONS[1])
+                || type.equals(SUPPORTED_MODULE_EXTENSIONS[2]);
     }
 }

--- a/src/main/java/org/openmrs/maven/plugins/utility/Wizard.java
+++ b/src/main/java/org/openmrs/maven/plugins/utility/Wizard.java
@@ -1,15 +1,13 @@
 package org.openmrs.maven.plugins.utility;
 
 import org.apache.maven.plugin.MojoExecutionException;
-import org.openmrs.maven.plugins.model.Artifact;
+import org.openmrs.maven.plugins.model.DistroProperties;
 import org.openmrs.maven.plugins.model.Server;
+import org.openmrs.maven.plugins.model.UpgradeDifferential;
 
 import java.io.File;
 import java.util.List;
 
-/**
- * Created by user on 30.05.16.
- */
 public interface Wizard {
     void promptForNewServerIfMissing(Server server);
 
@@ -23,7 +21,7 @@ public interface Wizard {
 
     String promptForPlatformVersion(List<String> versions);
 
-    void promptForDistroVersionIfMissing(Server server);
+    void promptForDistroVersionIfMissing(Server server) throws MojoExecutionException;
 
     String promptForDistroVersion();
 
@@ -38,8 +36,6 @@ public interface Wizard {
     String promptForValueWithDefaultList(String value, String parameterName, String defaultValue, List<String> values);
 
     String promptForValueIfMissing(String value, String parameterName);
-
-    Artifact parseDistro(String distro);
 
     boolean promptForInstallDistro();
 
@@ -56,4 +52,7 @@ public interface Wizard {
     String addMySQLParamsIfMissing(String dbUri);
 
     void showJdkErrorMessage(String jdk, String platform, String recommendedJdk, String pathToProps);
+
+    boolean promptForConfirmDistroUpgrade(UpgradeDifferential upgradeDifferential, Server server, DistroProperties distroProperties);
+
 }

--- a/src/test/java/org/openmrs/maven/plugins/ServerTest.java
+++ b/src/test/java/org/openmrs/maven/plugins/ServerTest.java
@@ -15,39 +15,32 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  *
  */
-public class ServerUpgraderTest {
-	ServerUpgrader serverUpgrader;
+public class ServerTest {
+	Server server;
 
 	@Before
 	public void setUp(){
-		serverUpgrader = new ServerUpgrader(new AbstractTask() {
-			@Override
-			public void execute() throws MojoExecutionException, MojoFailureException {
-
-			}
-		});
+		server = new Server.ServerBuilder().build();
 	}
 
 	@Test
 	public void testParseUserModules() throws Exception{
-		Server server = new Server.ServerBuilder().build();
 		String testUserModules = "org.openmrs.module/owa/1.4-SNAPSHOT," +
 				"org.openmrs.module/uicommons/1.7,org.openmrs.module/webservices.rest/2.15-SNAPSHOT";
 		Artifact owaModule = new Artifact("owa", "1.4-SNAPSHOT", "org.openmrs.module");
 
 		server.setParam(Server.PROPERTY_USER_MODULES, testUserModules);
-		List<Artifact> artifacts = serverUpgrader.parseUserModules(server);
+		List<Artifact> artifacts = server.getUserModules();
 		assertThat(artifacts.size(), is(3));
 		checkIfAnyArtifactMatches(artifacts, owaModule);
 	}
 
 	@Test(expected = MojoExecutionException.class)
 	public void testParseUserModulesShouldThrowParseExc() throws Exception{
-		Server server = new Server.ServerBuilder().build();
 		String brokenUserModules = "org.openmrs.module/owa/1.4-SNAPSHOT," +
 				"org.openmrs.module/uico7,org.openmrs.module/webservices.rest/2.15-SNAPSHOT";
 		server.setParam(Server.PROPERTY_USER_MODULES, brokenUserModules);
-		List<Artifact> artifacts = serverUpgrader.parseUserModules(server);
+		List<Artifact> artifacts = server.getUserModules();
 	}
 
 	private void checkIfAnyArtifactMatches(List<Artifact> artifacts, Artifact searched) {

--- a/src/test/java/org/openmrs/maven/plugins/utility/DistroHelperTest.java
+++ b/src/test/java/org/openmrs/maven/plugins/utility/DistroHelperTest.java
@@ -1,0 +1,133 @@
+package org.openmrs.maven.plugins.utility;
+
+import org.junit.Test;
+import org.openmrs.maven.plugins.model.Artifact;
+import org.openmrs.maven.plugins.model.UpgradeDifferential;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.core.Is.is;
+
+/**
+ *
+ */
+public class DistroHelperTest {
+
+    @Test
+    public void parseDistroArtifactShouldInferArtifactIdForRefapp() throws Exception{
+        String distro = "referenceapplication:2.3";
+        Artifact artifact = DistroHelper.parseDistroArtifact(distro);
+
+        assertThat(artifact.getGroupId(), is(Artifact.GROUP_DISTRO));
+        assertThat(artifact.getArtifactId(), is(SDKConstants.REFERENCEAPPLICATION_ARTIFACT_ID));
+    }
+    @Test
+    public void parseDistroArtifactShouldSetDefaultGroupIdIfNotSpecified() throws Exception{
+        String distro = "otherdistro:2.3";
+        Artifact artifact = DistroHelper.parseDistroArtifact(distro);
+
+        assertThat(artifact.getGroupId(), is(Artifact.GROUP_DISTRO));
+    }
+    @Test
+    public void parseDistroArtifactShouldReturnNullIfInvalidFormat() throws Exception{
+        String distro = "referenceapplication:2.3:fsf:444";
+        Artifact artifact = DistroHelper.parseDistroArtifact(distro);
+        assertThat(artifact, is(nullValue()));
+    }
+    @Test
+    public void parseDistroArtifactShouldCreateProperArtifact() throws Exception{
+        String distro = "org.openmrs.distromock:refapp:2.3";
+        Artifact artifact = DistroHelper.parseDistroArtifact(distro);
+
+        assertThat(artifact.getGroupId(), is("org.openmrs.distromock"));
+        assertThat(artifact.getArtifactId(), is("refapp"));
+        assertThat(artifact.getVersion(), is("2.3"));
+    }
+    @Test
+    public void calculateUpdateDifferentialShouldFindArtifactsToAddList() throws Exception{
+        UpgradeDifferential upgradeDifferential = DistroHelper.calculateUpdateDifferential(getMockOldArtifactList(), getMockNewArtifactList());
+
+        assertThat(upgradeDifferential.getModulesToAdd(), hasItem(new Artifact("drugs", "0.2-SNAPSHOT")));
+        assertThat(upgradeDifferential.getModulesToAdd(), hasSize(1));
+    }
+    @Test
+    public void calculateUpdateDifferentialShouldAddSnapshotToUpdateMap() throws Exception{
+        UpgradeDifferential upgradeDifferential = DistroHelper.calculateUpdateDifferential(getMockOldArtifactList(), getMockNewArtifactList());
+
+        assertThat(upgradeDifferential.getUpdateOldToNewMap().keySet(), hasItem(new Artifact("appui", "0.1-SNAPSHOT")));
+        assertThat(upgradeDifferential.getUpdateOldToNewMap().keySet(), hasItem(new Artifact("webservices","1.0")));
+        assertThat(upgradeDifferential.getUpdateOldToNewMap().values(), hasItem(new Artifact("webservices","1.2")));
+        assertThat(upgradeDifferential.getUpdateOldToNewMap().keySet(), hasSize(2));
+    }
+
+    @Test
+    public void calculateUpdateDifferentialShouldFindPlatformUpdate() throws Exception{
+        Artifact oldPlatform = new Artifact("openmrs-webapp", "10.7", Artifact.GROUP_WEB, Artifact.TYPE_WAR);
+        Artifact newPlatform = new Artifact("openmrs-webapp", "12.0", Artifact.GROUP_WEB, Artifact.TYPE_WAR);
+
+        UpgradeDifferential upgradeDifferential = DistroHelper.calculateUpdateDifferential(Arrays.asList(oldPlatform), Arrays.asList(newPlatform));
+        assertThat(upgradeDifferential.getPlatformArtifact(), is(newPlatform));
+    }
+
+    @Test
+    public void calculateUpgradeDifferentialShouldReturnEmptyListIfOlderModules() throws Exception{
+        UpgradeDifferential upgradeDifferential = DistroHelper.calculateUpdateDifferential(getMockOldArtifactList(), getMockOldestArtifactList());
+
+        assertThat(upgradeDifferential.getPlatformArtifact(), is(nullValue()));
+        assertThat(upgradeDifferential.getModulesToAdd(), is(empty()));
+        assertThat(upgradeDifferential.getUpdateOldToNewMap().values(), is(empty()));
+    }
+
+    @Test
+    public void calculateUpgradeDifferentialShouldReturnOnlyUpdateSnapshotsIfSameList() throws Exception{
+        UpgradeDifferential upgradeDifferential = DistroHelper.calculateUpdateDifferential(getMockOldArtifactList(), getMockOldArtifactList());
+
+        assertThat(upgradeDifferential.getPlatformArtifact(), is(nullValue()));
+        assertThat(upgradeDifferential.getModulesToAdd(), is(empty()));
+        assertThat(upgradeDifferential.getUpdateOldToNewMap().keySet(), hasSize(1));
+        assertThat(upgradeDifferential.getUpdateOldToNewMap().keySet(), hasItem(new Artifact("appui", "0.1-SNAPSHOT")));
+    }
+
+
+    private List<Artifact> getMockOldestArtifactList(){
+        List<Artifact> oldList = new ArrayList<>();
+        oldList.addAll(Arrays.asList(
+                new Artifact("webservices","0.7"),
+                new Artifact("webapp", "1.7"),
+                new Artifact("openmrs-webapp", "10.7", Artifact.GROUP_WEB, Artifact.TYPE_WAR)
+        ));
+
+        return oldList;
+    }
+
+    private List<Artifact> getMockOldArtifactList(){
+        List<Artifact> oldList = new ArrayList<>();
+        oldList.addAll(Arrays.asList(
+                new Artifact("webservices","1.0"),
+                new Artifact("webapp", "1.12"),
+                new Artifact("appui", "0.1-SNAPSHOT"),
+                new Artifact("openmrs-webapp", "10.7", Artifact.GROUP_WEB, Artifact.TYPE_WAR)
+        ));
+
+        return oldList;
+    }
+
+    private List<Artifact> getMockNewArtifactList(){
+        List<Artifact> oldList = new ArrayList<>();
+        oldList.addAll(Arrays.asList(
+                new Artifact("webservices","1.2"),
+                new Artifact("webapp", "1.12"),
+                new Artifact("appui", "0.1-SNAPSHOT"),
+                new Artifact("drugs", "0.2-SNAPSHOT"),
+                new Artifact("openmrs-webapp", "12.0", Artifact.GROUP_WEB, Artifact.TYPE_WAR)
+        ));
+        return oldList;
+    }
+}

--- a/src/test/java/org/openmrs/maven/plugins/utility/VersionsHelperTest.java
+++ b/src/test/java/org/openmrs/maven/plugins/utility/VersionsHelperTest.java
@@ -1,4 +1,4 @@
-package org.openmrs.maven.plugins;
+package org.openmrs.maven.plugins.utility;
 
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;

--- a/src/test/java/org/openmrs/maven/plugins/utility/WizardTest.java
+++ b/src/test/java/org/openmrs/maven/plugins/utility/WizardTest.java
@@ -1,4 +1,4 @@
-package org.openmrs.maven.plugins;
+package org.openmrs.maven.plugins.utility;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;


### PR DESCRIPTION
This PR introduces changes:
1. `install` goal supports upgrading server with openmrs-distro.properties file as specified in [issue description](https://issues.openmrs.org/browse/SDK-94)
2. part of `ServerUpgrader` code was moved to `Reset`, because it is not longer used in procedure of upgrading server
3. new class `DistroHelper` contains basic reusable methods like obtaining distro properties based on user input
4. add methods to Server class to make managing installed and user modules easier
5. fixed bug in upgrading single module - old version module was not erased from Server properties user module field
