### PR TITLE
SDK-94 fix failing DistroHelper test

### DIFF
--- a/src/test/java/org/openmrs/maven/plugins/utility/DistroHelperTest.java
+++ b/src/test/java/org/openmrs/maven/plugins/utility/DistroHelperTest.java
@@ -1,5 +1,6 @@
 package org.openmrs.maven.plugins.utility;
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.junit.Test;
 import org.openmrs.maven.plugins.model.Artifact;
 import org.openmrs.maven.plugins.model.UpgradeDifferential;
@@ -35,11 +36,10 @@ public class DistroHelperTest {
 
         assertThat(artifact.getGroupId(), is(Artifact.GROUP_DISTRO));
     }
-    @Test
+    @Test(expected = MojoExecutionException.class)
     public void parseDistroArtifactShouldReturnNullIfInvalidFormat() throws Exception{
         String distro = "referenceapplication:2.3:fsf:444";
-        Artifact artifact = DistroHelper.parseDistroArtifact(distro);
-        assertThat(artifact, is(nullValue()));
+        DistroHelper.parseDistroArtifact(distro);
     }
     @Test
     public void parseDistroArtifactShouldCreateProperArtifact() throws Exception{


### PR DESCRIPTION
After code review of #35 I have changed behaviour of DistoHelper#parseDistroArtifact method to throw exception when passed String is invalid, but didn't adjust test case, this commit fixes it.
